### PR TITLE
Fix typo from Minutes to Hours

### DIFF
--- a/src/main/kotlin/task11/inlineClasses/task04.kt
+++ b/src/main/kotlin/task11/inlineClasses/task04.kt
@@ -34,7 +34,7 @@ class MailScheduler {
  * After some research, you figure out that the delay is meant to be in minutes.
  *
  * - Write a wrapper as an inline class (Days), that takes an Int parameter (value).
- * - Give the Days class a toHours() function that returns a instance of Minutes.
+ * - Give the Days class a toHours() function that returns a instance of Hours.
  * - In task4Value(), create an instance of Days and set value to numberOfDays. Return value.
  * - In task4ToHours(), create an instance of Days and set value to numberOfDays. Return Days.toHours().
  * - In task4ToMinutes(), create an instance of Days and set value to numberOfDays. Return Hours.toMinutes().


### PR DESCRIPTION
Seems like a `toHours`-function should be returning an instance of `Hours`, not `minutes`