### PR TITLE
changed call to respondText to not use lambda

### DIFF
--- a/src/main/kotlin/task11/ktor/task01/taskA/taskA.kt
+++ b/src/main/kotlin/task11/ktor/task01/taskA/taskA.kt
@@ -37,7 +37,7 @@ fun main() {
 
         routing {
             get<Root.Cocktail> {
-                call.respondText { "Imma here!" }
+                call.respondText("Imma here!")
             }
         }
     }.start(wait = true)


### PR DESCRIPTION
the switch from `call.respondText { "Data" }` to `call.respond(data)`
introduces a complexity that is not needed in the tasks.

By changing it to `call.respondText("Data") we never expose the
participants to the lambda-variant, and thus remove this complexity